### PR TITLE
Write more meaningful message when fields defined as ObjectField raise ValueError with non-dict values

### DIFF
--- a/asyncmongoorm/field.py
+++ b/asyncmongoorm/field.py
@@ -27,6 +27,8 @@ class Field(object):
                 value = self.field_type(value)
             except TypeError:
                 raise(TypeError("type of %s must be %s" % (self.name, self.field_type)))
+            except ValueError:
+                raise(TypeError("type of %s must be %s" % (self.name, self.field_type)))
 
         instance._data[self.name] = value
 


### PR DESCRIPTION
If you have a Collection instance with ObjectField, and try to assign non-dict value to it the following exception is thrown:

File "/home/project/lib/python2.7/site-packages/asyncmongoorm/field.py", line 28, in **set**
  value = self.field_type(value)
ValueError: dictionary update sequence element #0 has length 1; 2 is required
